### PR TITLE
[license] Incorrect license is specified for pyclustering 0.10.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pyclustering
 
 Home: https://github.com/annoviko/pyclustering
 
-Package license: GPL-3.0
+Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyclustering-feedstock/blob/master/LICENSE.txt)
 
@@ -11,7 +11,7 @@ Summary: pyclustring is a python data mining library
 
 Development: https://github.com/annoviko/pyclustering
 
-Documentation: https://pyclustering.github.io/docs/0.9.2/html/index.html
+Documentation: https://pyclustering.github.io/docs/0.10.1/html/index.html
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,11 +63,10 @@ test:
 
 about:
   home: https://github.com/annoviko/pyclustering
-  license: GPL-3.0
-  license_family: GPL3
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: pyclustring is a python data mining library
-  doc_url: https://pyclustering.github.io/docs/0.9.2/html/index.html
+  doc_url: https://pyclustering.github.io/docs/0.10.1/html/index.html
   dev_url: https://github.com/annoviko/pyclustering
 
 extra:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hello! I have noticed that `pyclustering` is on `conda-forge` channel. There are two issues which are corrected by this PR:
- Incorrect license. Since `0.10.1`, it is distributed under `BSD-3-Clause` (see: [pypi](https://pypi.org/project/pyclustering/), [github](https://github.com/annoviko/pyclustering))
- Update link to the latest documentation `0.10.1` instead of `0.9.2`.

And I am not sure what else is required in order to fix on the conda-forge page (https://anaconda.org/conda-forge/pyclustering):
![image](https://user-images.githubusercontent.com/6785869/99959664-b5e01e00-2d8b-11eb-9c03-757253dc9b44.png)

